### PR TITLE
[Fix] 공동 송금 memberCount 로직 수정

### DIFF
--- a/src/entities/groupRemit/groupRemit.store.js
+++ b/src/entities/groupRemit/groupRemit.store.js
@@ -8,7 +8,6 @@ export const useGroupRemitStore = defineStore(
       currency: '',
       remittanceDate: null,
       amount: null,
-      memberCount: null,
       commission: 5000,
       isSignedUp: false,
     });

--- a/src/features/groupRemit/ui/GroupCollect.vue
+++ b/src/features/groupRemit/ui/GroupCollect.vue
@@ -19,7 +19,6 @@ const handleClick = (item) => {
   store.setGroupRemitInfo({
     currency: selectedType.value,
     remittanceDate: item.day,
-    memberCount: item.memberCount,
   });
 
   router.push(URL.PAGE.GROUP_SIGNUP);

--- a/src/pages/groupRemit/GroupSignupPage.vue
+++ b/src/pages/groupRemit/GroupSignupPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, computed } from 'vue';
+import { ref, reactive, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import URL from '@/shared/constants/URL';
 import Head3 from '@/shared/components/atoms/typography/Head3.vue';
@@ -9,11 +9,12 @@ import RemitInput from '@/features/groupRemit/ui/RemitInput.vue';
 import RecipientInput from '@/features/groupRemit/ui/RecipientInput.vue';
 import { joinGroupRemit } from '@/features/groupRemit/service/groupRemit.service';
 import { useGroupRemitStore } from '@/entities/groupRemit/groupRemit.store';
+import { getMemberCount } from '@/features/groupRemit/service/groupRemit.service';
 
 const router = useRouter();
 const store = useGroupRemitStore();
 const remittanceDate = computed(() => store.groupRemitInfo.remittanceDate);
-const memberCount = computed(() => store.groupRemitInfo.memberCount);
+const memberCount = ref(null);
 
 const selected = ref('remit');
 const joinData = reactive({
@@ -32,6 +33,16 @@ const joinData = reactive({
 const showError = ref(false);
 const errorMessage = ref('');
 
+const getMemberCountByDay = async () => {
+  const result = await getMemberCount({
+    currency: store.groupRemitInfo.currency,
+  });
+
+  const matched = result.data.find((item) => item.day === remittanceDate.value);
+
+  memberCount.value = matched?.memberCount ?? 0;
+};
+
 const handleComplete = async () => {
   const result = await joinGroupRemit(joinData);
 
@@ -43,6 +54,10 @@ const handleComplete = async () => {
     errorMessage.value = result.message;
   }
 };
+
+onMounted(() => {
+  getMemberCountByDay();
+});
 </script>
 
 <template>


### PR DESCRIPTION
## 📌 관련 이슈

- #이슈번호
  > Close #이슈번호

## 📄 PR 상세 내용
- memberCount가 변동될 가능성을 고려해서 '공동 송금 신청하기' 페이지 진입 시 해당 날짜의 memberCount를 새로 불러오도록 수정함.

## 📸 이미지 (테스트 이미지 필수)

## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
